### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,33 @@
+name: Build Extension Package
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-dist
+          path: dist
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ _Coming soon_
 - **LWC**: Uses Lightning Web Components via lwc-webpack-plugin
 - **Code Quality**: Prettier and ESLint configured with Salesforce LWC standards
 - **Git Hooks**: Husky pre-commit hook runs formatting
+- **CI Build**: A GitHub Action builds `dist/` on each commit to main and uploads it as an artifact
 
 ### Available Scripts
 

--- a/src/content_scripts/modules/x/app/app.js
+++ b/src/content_scripts/modules/x/app/app.js
@@ -18,7 +18,9 @@ export default class App extends LightningElement {
   }
 
   _handleCommands = (request, sender, sendResponse) => {
-    if (request.action !== 'sendCommands') return;
+    if (request.action !== 'sendCommands') {
+      return;
+    }
     if (request?.data?.commands) {
       this.commands = Object.entries(request.data.commands)
         .flatMap(([className, rawArray]) =>
@@ -30,7 +32,9 @@ export default class App extends LightningElement {
   };
 
   _handleToggleCommandPalette = (request, sender, sendResponse) => {
-    if (request.action !== 'toggleCommandPalette') return;
+    if (request.action !== 'toggleCommandPalette') {
+      return;
+    }
     this.isCommandPalletVisible = !this.isCommandPalletVisible;
     return false;
   };


### PR DESCRIPTION
## Summary
- add GitHub Action to build extension on pushes to `main`
- document CI build in README
- fix ESLint warnings in `app.js`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684356eb9d048328b86cbc05b0963c37