### PR TITLE
Add OAuth dev setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ _Coming soon_
 - `npm run lint-fix`: Fix ESLint issues automatically
 - `npm run format`: Format code with Prettier
 
+### Authentication Setup
+
+Force Navigator Reloaded uses OAuth2 with PKCE to authorize against Salesforce. The Chrome OAuth settings live in `src/manifest.json`, the connected app is located in `sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded.connectedApp-meta.xml`, and the login logic is implemented in `src/background/auth/auth.js`.
+
+To configure authentication for development:
+
+1. Run `npm run dev` and load the extension from the `dist/` folder using **Load unpacked**. Chrome assigns a new extension ID each time; copy it from the extensions page.
+2. Update the `<callbackUrl>` in the connected app metadata to `https://<extension-id>.chromiumapp.org/oauth2`.
+3. Deploy the connected app with `npm --prefix sf run deploy` and retrieve it using `npm --prefix sf run retreive`. Copy the `<consumerKey>` value—deploying generates a new client ID.
+4. Replace the `oauth2.client_id` in `src/manifest.json` and the `CLIENT_ID` constant in `src/background/constants.js` with this consumer key.
+5. Reload the extension (or rerun `npm run dev`) and run the **Authorize Extension** command from the palette to start the login flow. Tokens are cached per org and refreshed automatically.
+
+Once a connected app is configured for a specific extension ID you can reuse it with any Salesforce org without redeploying.
+
 ## Roadmap
 
 See [backlog.md](backlog.md) for planned features and development tasks.


### PR DESCRIPTION
## Summary
- update the authentication instructions for contributors
- explain how to configure the connected app when running `npm run dev`
- note that a connected app can be reused across orgs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845d881f8d88328acaaababa2a71736