### PR TITLE
Add dynamic manifest key injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ _Coming soon_
 - **Code Quality**: Prettier and ESLint configured with Salesforce LWC standards
 - **Git Hooks**: Husky pre-commit hook runs formatting
 - **CI Build**: A GitHub Action builds `dist/` on each commit to main, zips it as `force-navigator-reloaded.zip`, and attaches it to the latest GitHub release
+- **Manifest Key Injection**: `webpack` injects the extension `key` and OAuth consumer key based on build mode. This keeps the extension ID stable for authentication.
 
 ### Available Scripts
 
@@ -70,15 +71,22 @@ _Coming soon_
 
 ### Authentication Setup
 
-Force Navigator Reloaded uses OAuth2 with PKCE to authorize against Salesforce. The Chrome OAuth settings live in `src/manifest.json`, the connected app is located in `sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded.connectedApp-meta.xml`, and the login logic is implemented in `src/background/auth/auth.js`.
+Force Navigator Reloaded uses OAuth2 with PKCE to authorize against Salesforce. The Chrome OAuth settings live in `src/manifest.json`, the connected apps are located in `sf/force-app/main/default/connectedApps`, and the login logic is implemented in `src/background/auth/auth.js`.
+
+The extension ID is stable thanks to the manifest `key` field. Production builds use ID `iniflnopffblekndhplennjijdcfkeak` while development builds use `fjcokiadigpmkojdlhbkbhimkcmjokon`.
+
+There are two connected app definitions in `sf/force-app/main/default/connectedApps`:
+
+- `Force_Navigator_Reloaded_Prod.connectedApp-meta.xml`
+- `Force_Navigator_Reloaded_Dev.connectedApp-meta.xml`
+  Use the appropriate one for your target environment.
 
 To configure authentication for development:
 
-1. Run `npm run dev` and load the extension from the `dist/` folder using **Load unpacked**. Chrome assigns a new extension ID each time; copy it from the extensions page.
-2. Update the `<callbackUrl>` in the connected app metadata to `https://<extension-id>.chromiumapp.org/oauth2`.
-3. Deploy the connected app with `npm --prefix sf run deploy` and retrieve it using `npm --prefix sf run retreive`. Copy the `<consumerKey>` value—deploying generates a new client ID.
-4. Replace the `oauth2.client_id` in `src/manifest.json` and the `CLIENT_ID` constant in `src/background/constants.js` with this consumer key.
-5. Reload the extension (or rerun `npm run dev`) and run the **Authorize Extension** command from the palette to start the login flow. Tokens are cached per org and refreshed automatically.
+1. Run `npm run dev` and load the extension from the `dist/` folder using **Load unpacked**. The extension ID will be `fjcokiadigpmkojdlhbkbhimkcmjokon`.
+2. Deploy the `Force_Navigator_Reloaded_Dev` connected app with `npm --prefix sf run deploy` and retrieve it using `npm --prefix sf run retreive`. Copy the `<consumerKey>` value—deploying generates a new client ID.
+3. Replace `DEV_CONSUMER_KEY` in the metadata file with this value. Webpack injects the consumer key into `manifest.json` and the `CLIENT_ID` constant automatically. Reload the extension (or rerun `npm run dev`) and run the **Authorize Extension** command from the palette to start the login flow. Tokens are cached per org and refreshed automatically.
+4. For production builds use the `Force_Navigator_Reloaded_Prod` connected app and replace `PROD_CONSUMER_KEY` with its consumer key before running `npm run build`.
 
 Once a connected app is configured for a specific extension ID you can reuse it with any Salesforce org without redeploying.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ There are two connected app definitions in `sf/force-app/main/default/connectedA
 - `Force_Navigator_Reloaded_Prod.connectedApp-meta.xml`
 - `Force_Navigator_Reloaded_Dev.connectedApp-meta.xml`
 
+Connected apps are configured for a specific extension ID. Same app is reused across any Salesforce org without actual
+deployment, even if the org where the app lived is deleted.
+
 ## Roadmap
 
 See [backlog.md](backlog.md) for planned features and development tasks.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ _Coming soon_
 - `npm run lint-fix`: Fix ESLint issues automatically
 - `npm run format`: Format code with Prettier
 
-### Authentication Setup
+### Authentication
 
 Force Navigator Reloaded uses OAuth2 with PKCE to authorize against Salesforce. The Chrome OAuth settings live in `src/manifest.json`, the connected apps are located in `sf/force-app/main/default/connectedApps`, and the login logic is implemented in `src/background/auth/auth.js`.
 
@@ -79,16 +79,6 @@ There are two connected app definitions in `sf/force-app/main/default/connectedA
 
 - `Force_Navigator_Reloaded_Prod.connectedApp-meta.xml`
 - `Force_Navigator_Reloaded_Dev.connectedApp-meta.xml`
-  Use the appropriate one for your target environment.
-
-To configure authentication for development:
-
-1. Run `npm run dev` and load the extension from the `dist/` folder using **Load unpacked**. The extension ID will be `fjcokiadigpmkojdlhbkbhimkcmjokon`.
-2. Deploy the `Force_Navigator_Reloaded_Dev` connected app with `npm --prefix sf run deploy` and retrieve it using `npm --prefix sf run retreive`. Copy the `<consumerKey>` value—deploying generates a new client ID.
-3. Replace `DEV_CONSUMER_KEY` in the metadata file with this value. Webpack injects the consumer key into `manifest.json` and the `CLIENT_ID` constant automatically. Reload the extension (or rerun `npm run dev`) and run the **Authorize Extension** command from the palette to start the login flow. Tokens are cached per org and refreshed automatically.
-4. For production builds use the `Force_Navigator_Reloaded_Prod` connected app and replace `PROD_CONSUMER_KEY` with its consumer key before running `npm run build`.
-
-Once a connected app is configured for a specific extension ID you can reuse it with any Salesforce org without redeploying.
 
 ## Roadmap
 

--- a/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Dev.connectedApp-meta.xml
+++ b/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Dev.connectedApp-meta.xml
@@ -3,11 +3,11 @@
     <contactEmail>info@example.com</contactEmail>
     <description>Oauth for Force Navigator, used to get urls for faster navigation in Salesforce.</description>
     <iconUrl>https://raw.githubusercontent.com/Damecek/force-navigator-reloaded/refs/heads/main/src/icons/icon16.png</iconUrl>
-    <label>Force Navigator Reloaded</label>
+    <label>Force Navigator Reloaded Dev</label>
     <logoUrl>https://raw.githubusercontent.com/Damecek/force-navigator-reloaded/refs/heads/main/src/icons/icon128.png</logoUrl>
     <oauthConfig>
-        <callbackUrl>https://fhfniahcfcangfnkipdnoldfcenglopm.chromiumapp.org/oauth2</callbackUrl>
-        <consumerKey>3MVG9dAEux2v1sLuNHpwtD8XoDOCh2LFdy7QFtq9V5s03mu72XswHI9w7DJG7EcCLko8DdXfZjrQRZmmHI3Dm</consumerKey>
+        <callbackUrl>https://fjcokiadigpmkojdlhbkbhimkcmjokon.chromiumapp.org/oauth2</callbackUrl>
+        <consumerKey>DEV_CONSUMER_KEY</consumerKey>
         <isAdminApproved>false</isAdminApproved>
         <isClientCredentialEnabled>false</isClientCredentialEnabled>
         <isCodeCredentialEnabled>false</isCodeCredentialEnabled>

--- a/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Prod.connectedApp-meta.xml
+++ b/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Prod.connectedApp-meta.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ConnectedApp xmlns="http://soap.sforce.com/2006/04/metadata">
+    <contactEmail>info@example.com</contactEmail>
+    <description>Oauth for Force Navigator, used to get urls for faster navigation in Salesforce.</description>
+    <iconUrl>https://raw.githubusercontent.com/Damecek/force-navigator-reloaded/refs/heads/main/src/icons/icon16.png</iconUrl>
+    <label>Force Navigator Reloaded Prod</label>
+    <logoUrl>https://raw.githubusercontent.com/Damecek/force-navigator-reloaded/refs/heads/main/src/icons/icon128.png</logoUrl>
+    <oauthConfig>
+        <callbackUrl>https://iniflnopffblekndhplennjijdcfkeak.chromiumapp.org/oauth2</callbackUrl>
+        <consumerKey>PROD_CONSUMER_KEY</consumerKey>
+        <isAdminApproved>false</isAdminApproved>
+        <isClientCredentialEnabled>false</isClientCredentialEnabled>
+        <isCodeCredentialEnabled>false</isCodeCredentialEnabled>
+        <isCodeCredentialPostOnly>false</isCodeCredentialPostOnly>
+        <isConsumerSecretOptional>true</isConsumerSecretOptional>
+        <isIntrospectAllTokens>false</isIntrospectAllTokens>
+        <isNamedUserJwtEnabled>false</isNamedUserJwtEnabled>
+        <isPkceRequired>true</isPkceRequired>
+        <isRefreshTokenRotationEnabled>true</isRefreshTokenRotationEnabled>
+        <isSecretRequiredForRefreshToken>false</isSecretRequiredForRefreshToken>
+        <isSecretRequiredForTokenExchange>false</isSecretRequiredForTokenExchange>
+        <isTokenExchangeEnabled>false</isTokenExchangeEnabled>
+        <scopes>Api</scopes>
+        <scopes>Web</scopes>
+        <scopes>RefreshToken</scopes>
+        <scopes>OpenID</scopes>
+    </oauthConfig>
+    <oauthPolicy>
+        <ipRelaxation>BYPASS</ipRelaxation>
+        <isTokenExchangeFlowEnabled>false</isTokenExchangeFlowEnabled>
+        <refreshTokenPolicy>infinite</refreshTokenPolicy>
+    </oauthPolicy>
+</ConnectedApp>

--- a/src/background/constants.js
+++ b/src/background/constants.js
@@ -9,8 +9,11 @@ export const MENU_CACHE_TTL = 3600 * 1000 * 24; // 12 hour
 export const ENTITY_CACHE_KEY = 'entityDefinitions';
 export const ENTITY_CACHE_TTL = 3600 * 1000 * 6; // 12 hour
 
-export const CLIENT_ID =
-  '3MVG9dAEux2v1sLuNHpwtD8XoDOCh2LFdy7QFtq9V5s03mu72XswHI9w7DJG7EcCLko8DdXfZjrQRZmmHI3Dm';
+/**
+ * OAuth2 consumer key injected at build time.
+ * @type {string}
+ */
+export const CLIENT_ID = __CLIENT_ID__;
 export const SCOPES = 'api refresh_token web openid';
 export const SF_TOKEN_CACHE_KEY = 'sfToken';
 export const SF_TOKEN_CACHE_TTL = 3600 * 1000 * 24; // 24 hour

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,6 @@
   },
   "permissions": ["storage", "identity", "tabs", "activeTab"],
   "oauth2": {
-    "client_id": "3MVG9dAEux2v1sLuNHpwtD8XoDOCh2LFdy7QFtq9V5s03mu72XswHI9w7DJG7EcCLko8DdXfZjrQRZmmHI3Dm",
     "scopes": ["api", "refresh_token", "web", "openid"]
   },
   "host_permissions": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,9 +2,17 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const LwcWebpackPlugin = require('lwc-webpack-plugin');
+const webpack = require('webpack');
 
 module.exports = (env, argv) => {
   const isProd = argv.mode === 'production';
+  const PROD_KEY =
+    'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoYbnK/4GIHiHK5i0bZ/7jk8w+ifhmNf4ULA/1LsHpdmN68eobjXLC3LMbZyzN1eXf8WfLSDPI9S9jM/BmCCuPt1ZxCbVSkIfjqfbzWe31NAJjP3UcYXi7ZX57MBXP/7Xj8c5faKiUalBlCm0qyVyGdlB5BhNA/KOFv9+2oIPGoRSTF7ZhiItlQ+wYX3kNhAkRvxi8bJlITqkrZgI8sWPMSNvOccvgvUEXjqxoU6+onDttQz9HGrbPm+XTS1mFPwSN4ZOTReqdQ4TMZqAFs9Ml31ax1pedSNMYsnaOpRTEVyLjDTVPumbhluVPxCPdeHfQjBbk0C0t4GwyyAF2EhDvQIDAQAB';
+  const DEV_KEY =
+    'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtr+pe1aE1YhsrBtMQO+PGGKgZ7wLjjjxHKP8oP27XLlNpbS4upjuX9IN/RtmZzO71dA5BRTm5kILUggFZOQchVRkP+Yj029BH3FEVKJJx7FvZWG5j+Q8IW1V1GwEWatrFeKCBHdtkp/+qWNniWq+eByviNHNUXF2c1wcztasYSffw0wHL0vjQKrw0Y6isFj6nooyQyT5NNhoJmxY4iSV8rvSFYjadkavkp7Cup1eN79EFcHgL6DOxH9h2UyfXclsD2uFljAiA6orGuTPp6YHiwqpHvRwqrdyIb/KPwroc4l5K+qmR4/nqPzu0sGBRizFC6GyXzU1NO8WPEZrocxiGQIDAQAB';
+  const PROD_CLIENT_ID = 'PRODUCTION_CONSUMER_KEY';
+  const DEV_CLIENT_ID =
+    '3MVG9dAEux2v1sLuNHpwtD8XoDOCh2LFdy7QFtq9V5s03mu72XswHI9w7DJG7EcCLko8DdXfZjrQRZmmHI3Dm';
   return {
     mode: argv.mode,
     devtool: isProd ? false : 'inline-source-map',
@@ -48,10 +56,29 @@ module.exports = (env, argv) => {
         }
       : {},
     plugins: [
+      new webpack.DefinePlugin({
+        __CLIENT_ID__: JSON.stringify(isProd ? PROD_CLIENT_ID : DEV_CLIENT_ID),
+      }),
       new LwcWebpackPlugin(),
       new CopyWebpackPlugin({
         patterns: [
-          { from: 'src/manifest.json', to: 'manifest.json' },
+          {
+            from: 'src/manifest.json',
+            to: 'manifest.json',
+            /**
+             * Inject Chrome extension key and OAuth consumer key based on mode.
+             * @param {Buffer} content raw manifest JSON
+             * @returns {string} transformed manifest JSON string
+             */
+            transform(content) {
+              const manifest = JSON.parse(content.toString());
+              manifest.key = isProd ? PROD_KEY : DEV_KEY;
+              manifest.oauth2.client_id = isProd
+                ? PROD_CLIENT_ID
+                : DEV_CLIENT_ID;
+              return JSON.stringify(manifest, null, 2);
+            },
+          },
           { from: 'src/popup.html', to: 'popup.html' },
           { from: 'src/icons', to: 'icons' },
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = (env, argv) => {
   const DEV_KEY =
     'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtr+pe1aE1YhsrBtMQO+PGGKgZ7wLjjjxHKP8oP27XLlNpbS4upjuX9IN/RtmZzO71dA5BRTm5kILUggFZOQchVRkP+Yj029BH3FEVKJJx7FvZWG5j+Q8IW1V1GwEWatrFeKCBHdtkp/+qWNniWq+eByviNHNUXF2c1wcztasYSffw0wHL0vjQKrw0Y6isFj6nooyQyT5NNhoJmxY4iSV8rvSFYjadkavkp7Cup1eN79EFcHgL6DOxH9h2UyfXclsD2uFljAiA6orGuTPp6YHiwqpHvRwqrdyIb/KPwroc4l5K+qmR4/nqPzu0sGBRizFC6GyXzU1NO8WPEZrocxiGQIDAQAB';
   const PROD_CLIENT_ID = 'PRODUCTION_CONSUMER_KEY';
-  const DEV_CLIENT_ID =
-    '3MVG9dAEux2v1sLuNHpwtD8XoDOCh2LFdy7QFtq9V5s03mu72XswHI9w7DJG7EcCLko8DdXfZjrQRZmmHI3Dm';
+  const DEV_CLIENT_ID = 'DEV_CONSUMER_KEY';
   return {
     mode: argv.mode,
     devtool: isProd ? false : 'inline-source-map',
@@ -73,6 +72,7 @@ module.exports = (env, argv) => {
             transform(content) {
               const manifest = JSON.parse(content.toString());
               manifest.key = isProd ? PROD_KEY : DEV_KEY;
+              manifest.name = manifest.name + (isProd ? '' : ' (Dev)');
               manifest.oauth2.client_id = isProd
                 ? PROD_CLIENT_ID
                 : DEV_CLIENT_ID;


### PR DESCRIPTION
## Summary
- add `key` entry to manifest for development
- update webpack build to replace key when in production mode
- document manifest key injection in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68469a4455c4832883d858868240bd9c