### PR TITLE
Automate chrome web store publish

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,6 +19,25 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Bump patch version
+        run: |
+          newver=$(npm version patch --no-git-tag-version)
+          echo "NEW_VERSION=${newver#v}" >> "$GITHUB_ENV"
+
+      - name: Update manifest version
+        run: npx dot-json src/manifest.json version "$NEW_VERSION"
+
+      - name: Commit version bump
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git
+          git add package.json src/manifest.json
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push origin HEAD
+
       - name: Build extension
         run: npm run build
 
@@ -35,6 +54,14 @@ jobs:
           files: force-navigator-reloaded.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Chrome web store
+        run: npx chrome-webstore-upload-cli@2 upload --source force-navigator-reloaded.zip --auto-publish
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
+          CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_REFRESH_TOKEN }}
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ _Coming soon_
 - **Code Quality**: Prettier and ESLint configured with Salesforce LWC standards
 - **Git Hooks**: Husky pre-commit hook runs formatting
 - **CI Build**: A GitHub Action builds `dist/` on each commit to main, zips it as `force-navigator-reloaded.zip`, and attaches it to the latest GitHub release
+- **Web Store Release**: On push to `main`, the workflow bumps the version, builds the extension, and uploads it to the Chrome Web Store
 - **Manifest Key Injection**: `webpack` injects the extension `key` and OAuth consumer key based on build mode. This keeps the extension ID stable for authentication.
 
 ### Available Scripts

--- a/backlog.md
+++ b/backlog.md
@@ -18,5 +18,5 @@ Mark each line with [x] when the task is completed.
 - [ ] performance: instantiate commands only on click/select in the command item class, now it is instantiated on command list load
 - [ ] [internationalize](https://developer.chrome.com/docs/extensions/reference/api/i18n#concepts_and_usage) the
       extension
-- [ ] create pipeline
+- [x] create pipeline
       for [publishing to chrome store](https://github.com/marketplace/actions/publish-chrome-extension-to-chrome-web-store)


### PR DESCRIPTION
## Summary
- automate patch version bump in package.yml workflow
- publish extension to the Chrome Web Store
- document the publishing workflow in README
- mark backlog item as complete

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684879467b108328be3b9de1601f7aaf