### PR TITLE
Run package workflow only on extension changes

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,13 @@ name: Build & Publish Extension
 on:
   push:
     branches: [ main ]
+    paths:
+      - "src/**"
+      - "web/**"
+      - "webpack.config.js"
+      - "lwc.config.json"
+      - "package.json"
+      - "package-lock.json"
 
 concurrency:
   group: build-extension-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ _Coming soon_
 - **Code Quality**: Prettier and ESLint configured with Salesforce LWC standards
 - **Git Hooks**: Husky pre-commit hook runs formatting
 - **CI Build**: A GitHub Action builds `dist/` on each commit to main, zips it as `force-navigator-reloaded.zip`, and attaches it to the latest GitHub release
-- **Web Store Release**: On push to `main`, the workflow bumps the version, builds the extension, and uploads it to the Chrome Web Store
+- **Web Store Release**: On push to `main` when the extension source changes, the workflow bumps the version, builds the extension, and uploads it to the Chrome Web Store
 - **Manifest Key Injection**: `webpack` injects the extension `key` and OAuth consumer key based on build mode. This keeps the extension ID stable for authentication.
 
 ### Available Scripts


### PR DESCRIPTION
## Summary
- trigger package workflow only when the extension source is modified
- document conditional release workflow in README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848a422470083288d9a41b5335e5e24