### PR TITLE
Remove unused OAuth scopes

### DIFF
--- a/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Dev.connectedApp-meta.xml
+++ b/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Dev.connectedApp-meta.xml
@@ -21,9 +21,7 @@
         <isSecretRequiredForTokenExchange>false</isSecretRequiredForTokenExchange>
         <isTokenExchangeEnabled>false</isTokenExchangeEnabled>
         <scopes>Api</scopes>
-        <scopes>Web</scopes>
         <scopes>RefreshToken</scopes>
-        <scopes>OpenID</scopes>
     </oauthConfig>
     <oauthPolicy>
         <ipRelaxation>BYPASS</ipRelaxation>

--- a/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Prod.connectedApp-meta.xml
+++ b/sf/force-app/main/default/connectedApps/Force_Navigator_Reloaded_Prod.connectedApp-meta.xml
@@ -21,9 +21,7 @@
         <isSecretRequiredForTokenExchange>false</isSecretRequiredForTokenExchange>
         <isTokenExchangeEnabled>false</isTokenExchangeEnabled>
         <scopes>Api</scopes>
-        <scopes>Web</scopes>
         <scopes>RefreshToken</scopes>
-        <scopes>OpenID</scopes>
     </oauthConfig>
     <oauthPolicy>
         <ipRelaxation>BYPASS</ipRelaxation>

--- a/src/background/constants.js
+++ b/src/background/constants.js
@@ -14,7 +14,7 @@ export const ENTITY_CACHE_TTL = 3600 * 1000 * 6; // 12 hour
  * @type {string}
  */
 export const CLIENT_ID = __CLIENT_ID__;
-export const SCOPES = 'api refresh_token web openid';
+export const SCOPES = 'api refresh_token';
 export const SF_TOKEN_CACHE_KEY = 'sfToken';
 export const SF_TOKEN_CACHE_TTL = 3600 * 1000 * 24; // 24 hour
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,7 @@
   },
   "permissions": ["storage", "identity", "tabs", "activeTab"],
   "oauth2": {
-    "scopes": ["api", "refresh_token", "web", "openid"]
+    "scopes": ["api", "refresh_token"]
   },
   "host_permissions": [
     "https://*.force.com/*",


### PR DESCRIPTION
## Summary
- remove Web and OpenID from connected app metadata
- restrict OAuth scopes to API and refresh token
- rebuild dist to verify manifest scopes

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a833b95048328bcdffa998918f057