### PR TITLE
Add bump script to sync versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ version might occasionally lag behind the latest release.
 - `npm run lint`: Run ESLint on source files
 - `npm run lint-fix`: Fix ESLint issues automatically
 - `npm run format`: Format code with Prettier
+- `npm run bump`: Increment minor version and sync to `src/manifest.json`
 
 ### Authentication
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "force-navigator-reloaded",
-  "version": "5.0.10",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "force-navigator-reloaded",
-      "version": "5.0.10",
+      "version": "5.1.0",
       "dependencies": {
         "@leeoniya/ufuzzy": "^1.0.18",
         "@webcomponents/custom-elements": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "force-navigator-reloaded",
-  "version": "5.0.10",
+  "version": "5.1.0",
   "scripts": {
     "build": "rm -rf dist && webpack --mode production",
     "dev": "webpack --mode development --watch",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint \"src/**/*.js\"",
     "lint-fix": "eslint \"src/**/*.js\" --fix",
     "format": "prettier --write \"src/**/*.{js,json,md,html}\"",
+    "bump": "npm version minor --no-git-tag-version && node ./scripts/syncManifestVersion.js",
     "prepare": "husky install"
   },
   "devDependencies": {

--- a/scripts/syncManifestVersion.js
+++ b/scripts/syncManifestVersion.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+);
+const manifestPath = path.join(__dirname, '..', 'src', 'manifest.json');
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+manifest.version = pkg.version;
+
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Force Navigator Reloaded",
   "manifest_version": 3,
-  "version": "5.0.10",
+  "version": "5.1.0",
   "description": "Fast, efficient Salesforce Lightning navigation with a command palette—search and act without leaving your keyboard.",
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
## Summary
- add `bump` npm script to increment minor version and sync `src/manifest.json`
- create `scripts/syncManifestVersion.js` helper
- document `npm run bump` in README

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684bd14b45288328a3632d865771e4c6