### PR TITLE
Add flow navigation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ search, navigate, and perform actions without leaving their keyboard. It is avai
 - **SLDS Integration**: Uses Salesforce Lightning Design System for a native look and feel
 - **Modern Architecture**: Built with [LWC OSS](https://lwc.dev/) (Lightning Web Components) for composable UI
 - **Dynamic Setup Menu Commands**: Fetches and caches Salesforce setup menu items directly from your org for quick access
+- **Flow Navigation**: Quickly open Flow definitions and active/latest versions
 - **Command-Controlled Palette Closing**: Commands can keep the palette open after execution when appropriate
 
 ## Installation

--- a/backlog.md
+++ b/backlog.md
@@ -5,7 +5,7 @@ Mark each line with [x] when the task is completed.
 
 - [ ] Error Handling: centralized input validation and error reporting in the UI
 - [ ] Command `Login as <username>` (User Switcher)
-- [ ] Add a list of active flows to the menu
+- [x] Add a list of active flows to the menu
 - [ ] Add SObject-specific submenu (fields, layout, etc.)
 - [ ] Settings Provider and UI for user preferences (theme, SetupNodes, custom commands, etc.)
 - [ ] Theme Engine with support for themes (Default, Dark, Unicorn, Solarized)

--- a/src/background/commandRegister.js
+++ b/src/background/commandRegister.js
@@ -197,29 +197,31 @@ async function getFlowCommands(hostname, connection) {
   }
   try {
     const flows = await fetchFlowDefinitionsFromSalesforce(connection);
-    const commands = flows.flatMap((f) => {
-      const label = f.LatestVersion?.MasterLabel;
-      if (!label) {
-        return [];
-      }
-      return [
-        {
+    const commands = [];
+    for (const f of flows) {
+      const label = f?.LatestVersion?.MasterLabel;
+      if (label) {
+        commands.push({
           id: `flow-definition-${f.Id}`,
           label: `Flow > Definition > ${label}`,
           path: `/lightning/setup/Flows/page?address=%2F${f.Id}`,
-        },
-        {
-          id: `flow-latest-${f.LatestVersionId}`,
-          label: `Flow > Latest Version > ${label}`,
-          path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.LatestVersionId}`,
-        },
-        {
-          id: `flow-active-${f.ActiveVersionId}`,
-          label: `Flow > Active Version > ${label}`,
-          path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.ActiveVersionId}`,
-        },
-      ];
-    });
+        });
+        if (f.LatestVersionId) {
+          commands.push({
+            id: `flow-latest-${f.Id}`,
+            label: `Flow > Latest Version > ${label}`,
+            path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.LatestVersionId}`,
+          });
+        }
+        if (f.ActiveVersionId) {
+          commands.push({
+            id: `flow-active-${f.Id}`,
+            label: `Flow > Active Version > ${label}`,
+            path: `/builder_platform_interaction/flowBuilder.app?flowId=${f.ActiveVersionId}`,
+          });
+        }
+      }
+    }
     console.log('Commands', commands);
     if (commands.length > 0) {
       await cache.set(FLOW_CACHE_KEY, commands, FLOW_CACHE_TTL);

--- a/src/background/salesforceUtils.js
+++ b/src/background/salesforceUtils.js
@@ -46,3 +46,24 @@ export async function fetchEntityDefinitionsFromSalesforce(connection) {
   console.log('EntityDefinition query result', result);
   return result;
 }
+
+/**
+ * @typedef {Object} FlowDefinition
+ * @property {string} ActiveVersionId
+ * @property {string} Id
+ * @property {string} LatestVersionId
+ * @property {{ MasterLabel: string }} LatestVersion
+ */
+
+/**
+ * Fetch flow definitions via Tooling API.
+ * @param {SalesforceConnection} connection Salesforce connection instance
+ * @returns {Promise<FlowDefinition[]>}
+ */
+export async function fetchFlowDefinitionsFromSalesforce(connection) {
+  const result = await connection.toolingQuery(
+    `SELECT ActiveVersionId, Id, LatestVersionId, LatestVersion.MasterLabel FROM FlowDefinition`
+  );
+  console.log('FlowDefinition query result', result);
+  return result;
+}

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.css
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.css
@@ -5,11 +5,16 @@
     left: 50%;
     transform: translate(-50%, 0);
     width: 400px;
-    z-index: 1000000;
+    z-index: 10000;
 }
 
 .slds-modal__content {
     overflow: visible;
+}
+
+
+.slds-modal {
+    z-index: 9060;
 }
 
 .slds-scope .slds-modal__content {

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -9,7 +9,14 @@ export const MENU_CACHE_TTL = 3600 * 1000 * 24; // 12 hour
 export const ENTITY_CACHE_KEY = 'entityDefinitions';
 export const ENTITY_CACHE_TTL = 3600 * 1000 * 6; // 12 hour
 
-export const COMMAND_CACHE_KEYS = [MENU_CACHE_KEY, ENTITY_CACHE_KEY];
+export const FLOW_CACHE_KEY = 'flowDefinitions';
+export const FLOW_CACHE_TTL = 3600 * 1000 * 3; // 3 hour
+
+export const COMMAND_CACHE_KEYS = [
+  MENU_CACHE_KEY,
+  ENTITY_CACHE_KEY,
+  FLOW_CACHE_KEY,
+];
 
 /**
  * OAuth2 consumer key injected at build time.


### PR DESCRIPTION
## Summary
- add caching constants for flow commands
- fetch flow definitions via Tooling API
- register flow commands in command palette
- document new feature and mark backlog item done
- include flow cache key in refresh command list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685bf3123a38832884fb8c2501f5e27b