### PR TITLE
Refactor settings to use CacheManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ action.
 - **Popup** (`src/popup`): Provides quick usage tips and links to settings and GitHub, with automatic light/dark theme
   styling
 - **Options Page** (`src/options` and `src/options/modules`): Settings UI built with LWC
-- **Shared Utilities** (`src/shared`): Common modules for background and content scripts, including the Channel messaging wrapper and settings management
+- **Shared Utilities** (`src/shared`): Common modules for background and content scripts, including the Channel messaging wrapper, CacheManager, and settings management
 
 ### Build & Toolchain
 

--- a/src/shared/settings.js
+++ b/src/shared/settings.js
@@ -1,4 +1,4 @@
-/* global chrome */
+import CacheManager from './cacheManager.js';
 import {
   COMMANDS_SETTINGS_KEY,
   CUSTOM_METADATA_ENTITY_TYPE,
@@ -29,9 +29,11 @@ import {
 } from './constants.js';
 
 /**
- * Key used for persisting settings in chrome.storage.
+ * Key used for persisting settings.
  */
 export const SETTINGS_KEY = 'settings';
+
+const cache = new CacheManager('settings');
 
 /**
  * Default extension settings.
@@ -104,10 +106,10 @@ function mergeSettings(partial) {
  * @returns {Promise<typeof DEFAULT_SETTINGS>}
  */
 export async function loadSettings() {
-  const stored = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY];
+  const stored = await cache.get(SETTINGS_KEY);
   console.log('Loading settings', stored);
   const settings = mergeSettings(stored);
-  await chrome.storage.local.set({ [SETTINGS_KEY]: settings });
+  await cache.set(SETTINGS_KEY, settings);
   return settings;
 }
 
@@ -119,7 +121,7 @@ export async function loadSettings() {
 export async function saveSettings(settings) {
   console.log('Saving settings', settings);
   const merged = mergeSettings(settings);
-  await chrome.storage.local.set({ [SETTINGS_KEY]: merged });
+  await cache.set(SETTINGS_KEY, merged);
 }
 
 /**
@@ -128,7 +130,7 @@ export async function saveSettings(settings) {
  */
 export async function resetSettings() {
   console.log('Resetting settings to defaults');
-  await chrome.storage.local.remove(SETTINGS_KEY);
+  await cache.clear(SETTINGS_KEY);
   return loadSettings();
 }
 


### PR DESCRIPTION
## Summary
- use CacheManager in `settings.js` for persistent settings storage
- note CacheManager in shared utilities docs

## Testing
- `npm run lint`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_686e7c8b70f48328bdb0c74aa81e0080