### PR TITLE
Improve command palette toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ version might occasionally lag behind the latest release.
 3. Type commands or search terms to find what you need
 4. Press Enter to execute the selected command
 5. Press `Esc` or the same shortcut again to close the command palette
+   - When the palette is open but the input is not focused, pressing the shortcut refocuses the input instead of closing.
 6. Open the extension popup from the toolbar icon for quick help and a link to Settings
 7. Use the Settings page to edit the JSON configuration, tailoring which command sources (Setup nodes, objects, flows, custom commands) appear in the palette
 

--- a/src/content_scripts/modules/x/app/app.js
+++ b/src/content_scripts/modules/x/app/app.js
@@ -57,7 +57,20 @@ export default class App extends LightningElement {
 
   _handleToggleCommandPalette = () => {
     console.log('toggle command palette');
-    this.isCommandPaletteVisible = !this.isCommandPaletteVisible;
+    const palette = this.template.querySelector('x-command-pallet');
+    if (!this.isCommandPaletteVisible) {
+      this.isCommandPaletteVisible = true;
+    } else if (
+      palette &&
+      typeof palette.isInputFocused === 'function' &&
+      palette.isInputFocused()
+    ) {
+      this.isCommandPaletteVisible = false;
+    } else if (palette && typeof palette.focusInput === 'function') {
+      palette.focusInput();
+    } else {
+      this.isCommandPaletteVisible = false;
+    }
     return false;
   };
 

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.js
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.js
@@ -222,6 +222,23 @@ export default class CommandPallet extends LightningElement {
     this._visibleEnd = end;
   }
 
+  /**
+   * Returns true if the input element currently has focus.
+   * @returns {boolean}
+   */
+  isInputFocused() {
+    return this.refs.input === document.activeElement;
+  }
+
+  /**
+   * Focus the search input element.
+   */
+  focusInput() {
+    const inp = this.refs.input;
+    inp?.focus();
+    this._didFocus = true;
+  }
+
   get listStyle() {
     const height = this.filteredCommands.length * this._itemHeight;
     return `height:${height}px;position:relative;`;


### PR DESCRIPTION
## Summary
- keep command palette open when toggled without focus and regain focus
- expose input focus helpers in `x-command-pallet`
- document updated toggle behaviour

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687762078348832889fe7a5474611cdb