### PR TITLE
Refocus command palette when toggled without focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ version might occasionally lag behind the latest release.
 ## Usage
 
 1. Navigate to any Salesforce Lightning page
-2. Press `Ctrl+Shift+L` (or `Cmd+Shift+P` on Mac) to toggle the command palette
+2. Press `Ctrl+Shift+L` (or `Cmd+Shift+P` on Mac) to toggle the command palette. If the palette is open but not focused, the shortcut refocuses its input.
 3. Type commands or search terms to find what you need
 4. Press Enter to execute the selected command
-5. Press `Esc` or the same shortcut again to close the command palette
+5. Press `Esc` or the same shortcut again to close the command palette when it has focus
 6. Open the extension popup from the toolbar icon for quick help and a link to Settings
 7. Use the Settings page to edit the JSON configuration, tailoring which command sources (Setup nodes, objects, flows, custom commands) appear in the palette
 

--- a/backlog.md
+++ b/backlog.md
@@ -38,6 +38,7 @@ Mark each line with [x] when the task is completed.
 ```
 
 - [x] implement command usage prioritization or better sorting based on usage
+- [x] Toggle shortcut refocuses command palette when open without focus
 - [ ] performance: instantiate commands only on click/select in the command item class, now it is instantiated on
       command list load
 - [ ] [internationalize](https://developer.chrome.com/docs/extensions/reference/api/i18n#concepts_and_usage) the

--- a/src/content_scripts/modules/x/app/app.html
+++ b/src/content_scripts/modules/x/app/app.html
@@ -3,5 +3,6 @@
     commands={commands}
     lwc:if={isCommandPaletteVisible}
     onclose={handleClose}
+    lwc:ref="palette"
   ></x-command-pallet>
 </template>

--- a/src/content_scripts/modules/x/app/app.js
+++ b/src/content_scripts/modules/x/app/app.js
@@ -57,7 +57,16 @@ export default class App extends LightningElement {
 
   _handleToggleCommandPalette = () => {
     console.log('toggle command palette');
-    this.isCommandPaletteVisible = !this.isCommandPaletteVisible;
+    if (!this.isCommandPaletteVisible) {
+      this.isCommandPaletteVisible = true;
+    } else {
+      const activeElement = document.activeElement;
+      if (activeElement.name === 'command-input') {
+        this.isCommandPaletteVisible = false;
+      } else {
+        this.refs.palette?.focusInput();
+      }
+    }
     return false;
   };
 

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.html
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.html
@@ -55,6 +55,7 @@
                     autofocus
                     class="slds-input slds-combobox__input"
                     lwc:ref="input"
+                    name="command-input"
                     oninput={handleInput}
                     onkeydown={handleKeyDown}
                     placeholder="Type a command..."

--- a/src/content_scripts/modules/x/commandPallet/commandPallet.js
+++ b/src/content_scripts/modules/x/commandPallet/commandPallet.js
@@ -63,8 +63,7 @@ export default class CommandPallet extends LightningElement {
 
   renderedCallback() {
     if (!this._didFocus) {
-      const inp = this.refs.input;
-      inp?.focus();
+      this.focusInput();
       this._didFocus = true;
     }
     if (!this._scroller) {
@@ -149,6 +148,17 @@ export default class CommandPallet extends LightningElement {
 
   handleClose() {
     this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+  }
+
+  /**
+   * Programmatically focus the search input.
+   */
+  @api
+  focusInput() {
+    const inp = this.refs.input;
+    if (inp) {
+      inp.focus();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- Refine toggle logic so the command palette regains focus if already open, closes when focused, or opens when closed.
- Add `focusInput` API to command palette component for programmatic refocusing.
- Refactor focus logic to reuse `focusInput` method and remove duplication.
- Document new toggle behavior in README and backlog.

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e0096a308328bdc5c5631f9dd03d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved command palette shortcut behavior:
    - Opens when closed.
    - Refocuses the palette input if open but unfocused.
    - Closes when already focused (via shortcut or Esc).

* **Documentation**
  * Clarified Usage keyboard shortcuts to explain refocus and close behavior for the command palette.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->