### PR TITLE
Handle non-UI sObjects in Lightning navigation

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -53,5 +53,5 @@ Mark each line with [x] when the task is completed.
 > /tooling/query/?q=SELECT%20ActiveVersionId%2C%20Id%2C%20LatestVersionId%2C%20LatestVersion.MasterLabel%20FROM%20FlowDefinition →
 > 401: [{"message":"This session is not valid for use with the REST API","errorCode":"INVALID_SESSION_ID"}]
 
-- [ ] fix navigation to events **r and other sobjects which cannot be opened in Lightning
-      lightning/o/et4ae5**JB_Flow_Event\_\_e/list
+- [x] fix navigation to events and other sobjects which cannot be opened in Lightning
+      lightning/o/et4ae5JB_Flow_Event\_\_e/list

--- a/src/background/commandRegister.js
+++ b/src/background/commandRegister.js
@@ -42,6 +42,15 @@ import {
 import { SalesforceConnection } from './salesforceConnection';
 
 /**
+ * Determines whether an sObject supports Lightning record pages.
+ * @param {string} apiName sObject API name.
+ * @returns {boolean}
+ */
+function supportsLightningRecordUi(apiName) {
+  return !(apiName.endsWith('__e') || apiName.endsWith('__b'));
+}
+
+/**
  * Retrieves both static and dynamic commands for a given domain hostname.
  * @param {string} hostname Domain hostname (e.g., "myorg.lightning.force.com").
  * @returns {Promise<{NavigationCommand: import('./staticCommands').Command[], RefreshCommandListCommand: import('./staticCommands').Command[]}>} Object containing navigation commands and refresh command list.
@@ -296,16 +305,18 @@ async function getEntityCommands(hostname, connection) {
             path: `/lightning/setup/ObjectManager/${DurableId}/ValidationRules/view`,
           });
         }
-        commands.push({
-          id: `sobject-new-${QualifiedApiName}`,
-          label: `Application > ${Label} > New`,
-          path: `/lightning/o/${QualifiedApiName}/new`,
-        });
-        commands.push({
-          id: `sobject-list-${QualifiedApiName}`,
-          label: `Application > ${Label} > List View`,
-          path: `/lightning/o/${QualifiedApiName}/list`,
-        });
+        if (KeyPrefix && supportsLightningRecordUi(QualifiedApiName)) {
+          commands.push({
+            id: `sobject-new-${QualifiedApiName}`,
+            label: `Application > ${Label} > New`,
+            path: `/lightning/o/${QualifiedApiName}/new`,
+          });
+          commands.push({
+            id: `sobject-list-${QualifiedApiName}`,
+            label: `Application > ${Label} > List View`,
+            path: `/lightning/o/${QualifiedApiName}/list`,
+          });
+        }
       }
     }
     console.log('Entity Commands', commands.length, commands);


### PR DESCRIPTION
## Summary
- avoid generating record and list navigation for sObjects lacking Lightning UI (e.g. platform events and big objects)
- document completion of backlog item for unsupported sObjects

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61d8cf2fc8328a8c669cd8fad979b